### PR TITLE
fix 死龍武器模擬 total score issues

### DIFF
--- a/死龍武器模擬.html
+++ b/死龍武器模擬.html
@@ -333,12 +333,15 @@
             document.getElementById('total-count').textContent = `總分: ${total}分`;
         }
         function getTotalRandomOptions() {
+            let upperLimitList = document.getElementById('total-upper').value.split(",").map(item => item.trim());
+            const minUpperLimit = parseFloat(upperLimitList[0])
+            const maxUpperLimit = parseFloat(upperLimitList[1]);
             total = 0;
             let resultDiv = document.getElementById('result');
             searchCount = 0;
-            console.log(parseInt(document.getElementById('total-upper').value));
-            if (parseInt(document.getElementById('total-upper').value) < 0) {
-                while (parseInt(total) != -20) {
+            console.log(upperLimitList);
+            if (minUpperLimit < 0) {
+                while (parseFloat(total) != -20) {
                     total = 0;
                     let selected = [];
                     resultDiv.innerHTML = '';
@@ -366,7 +369,7 @@
                     searchCount++;
                 }
             } else {
-                while (parseInt(total) <= parseInt(document.getElementById('total-upper').value)) {
+                while (parseFloat(total) < minUpperLimit || parseFloat(total) > maxUpperLimit) {
                     total = 0;
                     let selected = [];
                     resultDiv.innerHTML = '';
@@ -417,13 +420,13 @@
         <div id="total-count" class="count-display">總分: 0分</div>
         <div id="click-count" class="count-display">轉換次數: 0次</div>
         <select id="total-upper">
-            <option value="-20">武器分解</option>
-            <option value="0">滾</option>
-            <option value="19">暫用</option>
-            <option value="22">小畢業(能用)</option>
-            <option value="25">畢業(核心模塊時間)</option>
-            <option value="30">大畢業</option>
-            <option value="33">陽壽人</option>
+            <option value="-20, 0">武器分解</option>
+            <option value="1, 18">滾</option>
+            <option value="19, 21">暫用</option>
+            <option value="22, 24">小畢業(能用)</option>
+            <option value="25, 29">畢業(核心模塊時間)</option>
+            <option value="30, 32">大畢業</option>
+            <option value="33, 33.5">陽壽人</option>
         </select>
         <button class="button" onclick="getTotalRandomOptions()">分數測試</button>
         <div id="ed-cost" class="ed-display"></div>


### PR DESCRIPTION
修正部分選項在執行分數測試時，執行結果會超出 ```total-upper``` 選項設定的分數。

### 此次修正的選項如下:
1. 滾
2. 暫用
3. 小畢業(能用)
4. 畢業(核心模塊時間)

### 實際問題:
**以選項 ```暫用``` 為例**  
該選項應當在 **19 ~ 21** 分區域之間  
執行結果如圖所示分數錯誤為 ```27.5```
![image](https://github.com/user-attachments/assets/41678455-c9cf-49a4-8f32-0c29de1c7a64)


### 預期結果: 
**以選項 ```暫用``` 為例**  
該選項的**每次**執行結果必須在 **19 ~ 21** 分區域之間
![image](https://github.com/user-attachments/assets/f0294f2f-f68e-4157-8dad-89d4c896edc2)